### PR TITLE
Fetch files for remote access

### DIFF
--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -80,3 +80,6 @@
     - 9701/tcp
     - 7389/tcp
     - 8443/tcp
+
+- name: Fetch krb5config
+  fetch: src=/etc/krb5.conf  dest={{ inventory_dir }}/krb5.conf  flat=yes

--- a/roles/packstack/tasks/main.yml
+++ b/roles/packstack/tasks/main.yml
@@ -35,3 +35,15 @@
     - demorc
     - kerb-accrc
     - fed-accrc
+
+
+
+- name: get local copies of rc files
+  sudo: no
+  local_action: template src={{ item }}.j2
+                      dest={{ deployment_dir  }}/{{ item }}
+  with_items:
+    - adminrc
+    - demorc
+    - kerb-accrc
+    - fed-accrc


### PR DESCRIPTION
Puts copies of files on the Ansible host that
can be used for remote access via Kerberos and
OpenStack APIs.
