### PR TITLE
Support Fedora installs

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -4,6 +4,10 @@
     - common
   selinux: state=disabled
 
+- name: Enable yum for Fedora
+  command: dnf install yum-utils -y
+  when: ansible_distribution == "Fedora" and ansible_distribution_major_version == "22"
+
 - name: Install repos
   tags:
     - common

--- a/roles/ipaclient/tasks/main.yml
+++ b/roles/ipaclient/tasks/main.yml
@@ -1,15 +1,26 @@
 ---
+
+- name: install FreeIPA Client packages
+  tags:
+    - ipaclient
+  yum: name=freeipa-client,freeipa-admintools,python-memcached
+  when: ansible_distribution == 'Fedora'
+
+
+
 - name: Install IPA Client packages
   tags:
     - ipaclient
   yum: name=ipa-client,ipa-admintools,python-memcached
        state=present
+  when: ansible_distribution == "RedHat"  or ansible_distribution == 'CentOS'
+
 
 - name: Setup resolv.conf
   tags:
     - ipaclient
   template: src=resolv.conf.j2
-            dest=/etc/resolv.conf
+	    dest=/etc/resolv.conf
 
 - name: Register IPA Client
   tags:

--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -1,22 +1,30 @@
 ---
-- name: install ipa packages
+
+- name: install freeipa packages
   tags:
     - ipaserver
   yum: name={{ item }} state=present
   with_items:
     - bind-dyndb-ldap
-    - ipa-server
     - firewalld
+    - freeipa-server
+    - bind-pkcs11
+    - bind-pkcs11-utils
+  when: ansible_distribution == 'Fedora'
 
-- name: ipa extra packages
+
+- name: ipa packages
   tags:
     - ipaserver
   yum: name={{ item }} state=present
   with_items:
+    - bind-dyndb-ldap
+    - firewalld
+    - ipa-server
     - bind-pkcs11
     - bind-pkcs11-utils
     - ipa-server-dns
-  when: ansible_distribution == "RedHat"
+  when: ansible_distribution == "RedHat"  or ansible_distribution == 'CentOS'
 
 - name: install ipa
   tags:
@@ -47,16 +55,16 @@
   tags:
     - ipaserver
   service: enabled=yes
-           state=started
-           name=firewalld
+	   state=started
+	   name=firewalld
 
 - name: Open Firewall for services
   tags:
     - ipaserver
   firewalld: service={{ item }}
-             permanent=true
-             state=enabled
-             immediate=yes
+	     permanent=true
+	     state=enabled
+	     immediate=yes
   with_items:
     - http
     - https
@@ -71,9 +79,9 @@
   tags:
     - ipaserver
   firewalld: port={{ item }}
-             permanent=true
-             state=enabled
-             immediate=yes
+	     permanent=true
+	     state=enabled
+	     immediate=yes
   with_items:
     - 9180/tcp
     - 9443-9446/tcp

--- a/roles/packstack/tasks/keystone.yml
+++ b/roles/packstack/tasks/keystone.yml
@@ -61,7 +61,7 @@
     - ecp
     - websso
 
-- name: Install Ipsilon
+- name: Install Ipsilon Client
   tags:
     - ipsilon
   shell: >


### PR DESCRIPTION
Handles most of the differences between RHEL and Fedora.  Explicitly looks for F22 due to the use of dnf
